### PR TITLE
Add option to skip shader build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,19 @@ cmake_minimum_required(VERSION 3.13.4)
 
 project(Vita_FinalRenderer)
 
+option(BUILD_SHADERS "Build and link shader binaries" ON)
+
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
 # add_subdirectory(src)
 # doing this will allow us to use the SHADER_OBJS variable in the src CMakeLists.txt file
-add_subdirectory(src ${CMAKE_CURRENT_BINARY_DIR}/src ${SHADER_OBJS})
+add_subdirectory(src ${CMAKE_CURRENT_BINARY_DIR}/src)
+
+if(BUILD_SHADERS)
+    message(STATUS "Shaders will be built and linked")
+else()
+    message(STATUS "Skipping shader build and linkage")
+endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     message(STATUS "Configuring with DEBUG settings")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_executable(${PROJECT_NAME} main.cpp matrix.h matrix.cpp commonUtils.h camera.h camera.cpp EMP_Logo.h EMP_Logo_Alpha.h light.h light.cpp terrain.h terrain.cpp terrainTextures.h)
-add_dependencies(${PROJECT_NAME} Shaders)
 set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".elf")
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
@@ -15,53 +14,55 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${VITASDK}/arm-vita-eabi/inclu
 
 link_directories(${PSVITA_LIBS_PATH})
 
-# generate shader targets
-file(GLOB SHADER_SRC "${CMAKE_SOURCE_DIR}/Shaders/*_v.cg" "${CMAKE_SOURCE_DIR}/Shaders/*_f.cg")
-foreach(shader ${SHADER_SRC})
-    string(REPLACE ".cg" ".gxp" shader_gxp ${shader})
-    string(REPLACE "Shaders/" "out/shaders/" shader_o ${shader_gxp})
-    string(REPLACE ".gxp" "_gxp.o" shader_o ${shader_o})
+if(BUILD_SHADERS)
+    # generate shader targets
+    file(GLOB SHADER_SRC "${CMAKE_SOURCE_DIR}/Shaders/*_v.cg" "${CMAKE_SOURCE_DIR}/Shaders/*_f.cg")
+    foreach(shader ${SHADER_SRC})
+        string(REPLACE ".cg" ".gxp" shader_gxp ${shader})
+        string(REPLACE "Shaders/" "out/shaders/" shader_o ${shader_gxp})
+        string(REPLACE ".gxp" "_gxp.o" shader_o ${shader_o})
 
-    # determine if vertex or fragment shader
-    if(shader MATCHES "_v\\.cg$")
-		set(SHADER_PROFILE "sce_vp_psp2")
-    else()
-        set(SHADER_PROFILE "sce_fp_psp2")
-    endif()
+        # determine if vertex or fragment shader
+        if(shader MATCHES "_v\\.cg$")
+            set(SHADER_PROFILE "sce_vp_psp2")
+        else()
+            set(SHADER_PROFILE "sce_fp_psp2")
+        endif()
 
-    # get the filename without directories or extension
-    get_filename_component(SHADER_FILENAME ${shader} NAME_WE)
-    get_filename_component(SHADER_FILENAME_WITH_EXTENSION ${shader} NAME)
-    get_filename_component(SHADER_GXP_FILENAME ${shader_gxp} NAME)
+        # get the filename without directories or extension
+        get_filename_component(SHADER_FILENAME ${shader} NAME_WE)
+        get_filename_component(SHADER_FILENAME_WITH_EXTENSION ${shader} NAME)
+        get_filename_component(SHADER_GXP_FILENAME ${shader_gxp} NAME)
 
-    # Compile cg to gxp
-    add_custom_command(
-        OUTPUT ${shader_gxp}
-        COMMAND psp2cgc -profile ${SHADER_PROFILE} ${SHADER_FILENAME_WITH_EXTENSION} -O3 -o ${shader_gxp}
-        DEPENDS ${shader}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Shaders
-        COMMENT "Compiling ${shader} to ${shader_gxp}"
-    )
+        # Compile cg to gxp
+        add_custom_command(
+            OUTPUT ${shader_gxp}
+            COMMAND psp2cgc -profile ${SHADER_PROFILE} ${SHADER_FILENAME_WITH_EXTENSION} -O3 -o ${shader_gxp}
+            DEPENDS ${shader}
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Shaders
+            COMMENT "Compiling ${shader} to ${shader_gxp}"
+        )
 
-    # Compile gxp to o
-    add_custom_command(
-        OUTPUT ${shader_o}
-		COMMAND arm-vita-eabi-objcopy --input-target binary --output-target elf32-littlearm
-            --binary-architecture arm --set-section-alignment .data=4 ${SHADER_GXP_FILENAME} ${shader_o}
-		DEPENDS ${shader_gxp}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Shaders
-		COMMENT "Objcopying ${shader_gxp} to ${shader_o}"
-	)
+        # Compile gxp to o
+        add_custom_command(
+            OUTPUT ${shader_o}
+            COMMAND arm-vita-eabi-objcopy --input-target binary --output-target elf32-littlearm --binary-architecture arm --set-section-alignment .data=4 ${SHADER_GXP_FILENAME} ${shader_o}
+            DEPENDS ${shader_gxp}
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Shaders
+            COMMENT "Objcopying ${shader_gxp} to ${shader_o}"
+        )
 
-    list(APPEND SHADER_OBJS ${shader_o})
-endforeach()
+        list(APPEND SHADER_OBJS ${shader_o})
+    endforeach()
 
-
-add_custom_target(Shaders DEPENDS ${SHADER_OBJS})
-
-# Link the executable to the library
-message(STATUS "Shader Objects: ${SHADER_OBJS}")
-target_link_libraries(${PROJECT_NAME} PRIVATE -Wl,-q -lm ${SHADER_OBJS} SceDisplay_stub SceGxm_stub SceCtrl_stub SceRtc_stub)
+    add_custom_target(Shaders DEPENDS ${SHADER_OBJS})
+    message(STATUS "Shader Objects: ${SHADER_OBJS}")
+    add_dependencies(${PROJECT_NAME} Shaders)
+    target_link_libraries(${PROJECT_NAME} PRIVATE -Wl,-q -lm ${SHADER_OBJS} SceDisplay_stub SceGxm_stub SceCtrl_stub SceRtc_stub)
+else()
+    add_custom_target(Shaders)
+    target_link_libraries(${PROJECT_NAME} PRIVATE -Wl,-q -lm SceDisplay_stub SceGxm_stub SceCtrl_stub SceRtc_stub)
+endif()
 
 add_custom_command(OUTPUT EBOOT.BIN
 	COMMAND vita-elf-create $<TARGET_FILE:${PROJECT_NAME}> ${PROJECT_NAME}.velf


### PR DESCRIPTION
## Summary
- add `BUILD_SHADERS` option to the main CMake file
- optionally skip shader compilation and linkage in `src/CMakeLists.txt`
- print messages indicating whether shaders are processed

## Testing
- `cmake -S . -B build`
- `cmake -S . -B build_noshader -DBUILD_SHADERS=OFF`


------
https://chatgpt.com/codex/tasks/task_e_688999f2473083278aca75bdff5227d1