### PR TITLE
Add PSVITA platform and fix Vita SDK include flags

### DIFF
--- a/Platform/PSVITA.cmake
+++ b/Platform/PSVITA.cmake
@@ -1,0 +1,6 @@
+# Minimal platform definition for PlayStation Vita
+# Presence of this file allows CMake to recognise PSVITA as a valid system.
+
+set(CMAKE_SYSTEM_NAME PSVITA)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+

--- a/psvita-toolchain.cmake
+++ b/psvita-toolchain.cmake
@@ -1,32 +1,35 @@
-#psvita-toolchain.cmake
+# psvita-toolchain.cmake
 
 if(DEFINED ENV{VITASDK})
-	message(STATUS "VITASDK environment variable set")
-	set(VITA_SDK $ENV{VITASDK})
-	set(CMAKE_C_FLAGS -I${VITA_SDK}/include -I${VITA_SDK}/arm-vita-eabi/include)
-	set(CMAKE_CXX_FLAGS -I${VITA_SDK}/include -I${VITA_SDK}/arm-vita-eabi/include -I${VITA_SDK}/arm-vita-eabi/include/c++/10.3.0)
-	set(PSVITA_LIBS_PATH ${VITA_SDK}/arm-vita-eabi/lib)
+    message(STATUS "VITASDK environment variable set")
+    set(VITA_SDK $ENV{VITASDK})
 else()
-	message(FATAL_ERROR "Please define VITASDK environment variable!")
+    message(FATAL_ERROR "Please define VITASDK environment variable!")
 endif()
+
+# Ensure CMake can find the PSVITA platform definition
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${VITA_SDK}/include -I${VITA_SDK}/arm-vita-eabi/include")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${VITA_SDK}/include -I${VITA_SDK}/arm-vita-eabi/include -I${VITA_SDK}/arm-vita-eabi/include/c++/10.3.0")
 
 set(CMAKE_SYSTEM_NAME PSVITA)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
-#specify cross compilers and tools
+# Specify cross compilers and tools
 set(CMAKE_C_COMPILER "arm-vita-eabi-gcc")
 set(CMAKE_CXX_COMPILER "arm-vita-eabi-g++")
 
-#only use the psvita toolchain, no host tools
+# Only use the PSVita toolchain, no host tools
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
-# I just added this and it doesn't seem to make a difference
-set(CMAKE_FIND_ROOT_PATH ${VITA_SDK}/arm-vita-eabi/include; ${VITA_SDK}/arm-vita-eabi/include/c++/10.3.0)
+set(CMAKE_FIND_ROOT_PATH
+    ${VITA_SDK}/arm-vita-eabi/include
+    ${VITA_SDK}/arm-vita-eabi/include/c++/10.3.0
+)
 
-#set the compiler flags #maybe do this in another CMakeLists.txt depending on build type
-#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-q -Wall -O3 -fno-short-enums")
-
-#specify the path to the ps vita libraries
+# Specify the path to the PS Vita libraries
 set(PSVITA_LIBS_PATH ${VITA_SDK}/arm-vita-eabi/lib)
+


### PR DESCRIPTION
## Summary
- provide minimal `Platform/PSVITA.cmake` so CMake recognizes the Vita target
- quote Vita SDK include paths and append to existing flags in toolchain file

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHADERS=OFF -DCMAKE_TOOLCHAIN_FILE=psvita-toolchain.cmake`
- `cmake --build build` *(fails: undefined reference to `_binary_clear_v_gxp_start` and related shader symbols)*

------
https://chatgpt.com/codex/tasks/task_e_688ecfa4ad8883279875461d8a582f93