### PR TITLE
Ensure shader directory creation and add build instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ option(SAFE_HOMEBREW "Sign the build as a safe homebrew" ON)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
+# Ensure the shader output directory exists even when BUILD_SHADERS is off
+set(SHADER_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/out/shaders")
+file(MAKE_DIRECTORY ${SHADER_OUTPUT_DIR})
+
 # add_subdirectory(src)
 # doing this will allow us to use the SHADER_OBJS variable in the src CMakeLists.txt file
 add_subdirectory(src ${CMAKE_CURRENT_BINARY_DIR}/src)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Vita Final Renderer
+
+This project targets the PlayStation Vita and uses the VitaSDK toolchain.
+
+## Prerequisites
+- [VitaSDK](https://vitasdk.org/) installed.
+- The following environment variables set in your shell before running CMake:
+  ```sh
+  export VITASDK=/path/to/vitasdk
+  export PATH="$VITASDK/bin:$PATH"
+  ```
+
+## Building
+1. Generate the build files using the PS Vita toolchain:
+   ```sh
+   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=psvita-toolchain.cmake
+   ```
+2. Compile and package the project:
+   ```sh
+   cmake --build build
+   ```
+


### PR DESCRIPTION
## Summary
- Guarantee `out/shaders` directory exists during configuration
- Document VitaSDK setup and build steps
- Remove redundant note about shader directory creation in README

## Testing
- `cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=psvita-toolchain.cmake`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_688ed65114508327a019b6dfb97ab403