### PR TITLE
Use precompiled shaders when BUILD_SHADERS is off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ add_subdirectory(src ${CMAKE_CURRENT_BINARY_DIR}/src)
 if(BUILD_SHADERS)
     message(STATUS "Shaders will be built and linked")
 else()
-    message(STATUS "Skipping shader build and linkage")
+    message(STATUS "Using precompiled shader binaries")
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This project targets the PlayStation Vita and uses the VitaSDK toolchain.
    ```sh
    cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=psvita-toolchain.cmake
    ```
+   To link against existing precompiled shader binaries instead of rebuilding them, add `-DBUILD_SHADERS=OFF`:
+   ```sh
+   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=psvita-toolchain.cmake -DBUILD_SHADERS=OFF
+   ```
 2. Compile and package the project:
    ```sh
    cmake --build build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,25 +20,23 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${VITASDK}/arm-vita-eabi/inclu
 
 link_directories(${PSVITA_LIBS_PATH})
 
-if(BUILD_SHADERS)
-    # generate shader targets
-    file(GLOB SHADER_SRC "${CMAKE_SOURCE_DIR}/Shaders/*_v.cg" "${CMAKE_SOURCE_DIR}/Shaders/*_f.cg")
-    foreach(shader ${SHADER_SRC})
-        string(REPLACE ".cg" ".gxp" shader_gxp ${shader})
-        string(REPLACE "Shaders/" "out/shaders/" shader_o ${shader_gxp})
-        string(REPLACE ".gxp" "_gxp.o" shader_o ${shader_o})
+# generate shader targets
+file(GLOB SHADER_SRC "${CMAKE_SOURCE_DIR}/Shaders/*_v.cg" "${CMAKE_SOURCE_DIR}/Shaders/*_f.cg")
+foreach(shader ${SHADER_SRC})
+    string(REPLACE ".cg" ".gxp" shader_gxp ${shader})
+    string(REPLACE "Shaders/" "out/shaders/" shader_o ${shader_gxp})
+    string(REPLACE ".gxp" "_gxp.o" shader_o ${shader_o})
 
+    get_filename_component(SHADER_FILENAME_WITH_EXTENSION ${shader} NAME)
+    get_filename_component(SHADER_GXP_FILENAME ${shader_gxp} NAME)
+
+    if(BUILD_SHADERS)
         # determine if vertex or fragment shader
         if(shader MATCHES "_v\\.cg$")
             set(SHADER_PROFILE "sce_vp_psp2")
         else()
             set(SHADER_PROFILE "sce_fp_psp2")
         endif()
-
-        # get the filename without directories or extension
-        get_filename_component(SHADER_FILENAME ${shader} NAME_WE)
-        get_filename_component(SHADER_FILENAME_WITH_EXTENSION ${shader} NAME)
-        get_filename_component(SHADER_GXP_FILENAME ${shader_gxp} NAME)
 
         # Compile cg to gxp
         add_custom_command(
@@ -48,27 +46,23 @@ if(BUILD_SHADERS)
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Shaders
             COMMENT "Compiling ${shader} to ${shader_gxp}"
         )
+    endif()
 
-        # Compile gxp to o
-        add_custom_command(
-            OUTPUT ${shader_o}
-            COMMAND arm-vita-eabi-objcopy --input-target binary --output-target elf32-littlearm --binary-architecture arm --set-section-alignment .data=4 ${SHADER_GXP_FILENAME} ${shader_o}
-            DEPENDS ${shader_gxp}
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Shaders
-            COMMENT "Objcopying ${shader_gxp} to ${shader_o}"
-        )
+    # Objcopy gxp to object file (uses precompiled gxp when BUILD_SHADERS is OFF)
+    add_custom_command(
+        OUTPUT ${shader_o}
+        COMMAND arm-vita-eabi-objcopy --input-target binary --output-target elf32-littlearm --binary-architecture arm --set-section-alignment .data=4 ${SHADER_GXP_FILENAME} ${shader_o}
+        DEPENDS ${shader_gxp}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Shaders
+        COMMENT "Objcopying ${shader_gxp} to ${shader_o}"
+    )
 
-        list(APPEND SHADER_OBJS ${shader_o})
-    endforeach()
+    list(APPEND SHADER_OBJS ${shader_o})
+endforeach()
 
-    add_custom_target(Shaders DEPENDS ${SHADER_OBJS})
-    message(STATUS "Shader Objects: ${SHADER_OBJS}")
-    add_dependencies(${PROJECT_NAME} Shaders)
-    target_link_libraries(${PROJECT_NAME} PRIVATE -Wl,-q -lm ${SHADER_OBJS} SceDisplay_stub SceGxm_stub SceCtrl_stub SceRtc_stub)
-else()
-    add_custom_target(Shaders)
-    target_link_libraries(${PROJECT_NAME} PRIVATE -Wl,-q -lm SceDisplay_stub SceGxm_stub SceCtrl_stub SceRtc_stub)
-endif()
+add_custom_target(Shaders DEPENDS ${SHADER_OBJS})
+add_dependencies(${PROJECT_NAME} Shaders)
+target_link_libraries(${PROJECT_NAME} PRIVATE -Wl,-q -lm ${SHADER_OBJS} SceDisplay_stub SceGxm_stub SceCtrl_stub SceRtc_stub)
 
 add_custom_command(OUTPUT EBOOT.BIN
 	COMMAND vita-elf-create $<TARGET_FILE:${PROJECT_NAME}> ${PROJECT_NAME}.velf


### PR DESCRIPTION
## Summary
- Link against existing precompiled shader binaries when `BUILD_SHADERS` is disabled.
- Document `BUILD_SHADERS` usage in the README.
- Reuse the existing shader object list so both build modes share the same linking logic.

## Testing
- `cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=psvita-toolchain.cmake -DBUILD_SHADERS=OFF`
- `cmake --build build --target Shaders`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_688ee37e4e24832786298dff1d0b1210